### PR TITLE
Fix root test/lint commands for pnpm monorepo

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc -b",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "setup-env": "sh setup-env.sh",
-    "lint": "eslint \"**/*.{js,ts,tsx}\" --max-warnings=0",
+    "lint": "pnpm --filter \"./apps/*\" lint",
+    "test": "pnpm --filter \"./apps/*\" test",
     "format": "prettier --write ."
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add root aggregator scripts for `pnpm test` and `pnpm lint`
- create real `lint` and `test` scripts in backend and frontend apps

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684e0b796394832ab19b24d1fa5f5037