### PR TITLE
Implement JWT-based auth with Sequelize user model

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,18 +7,27 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc -b",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1",
     "express": "^4.19.2",
-    "sequelize": "^6.37.0",
+    "express-validator": "^6.15.0",
+    "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.3",
-    "pluggy-sdk": "^0.72.1"
+    "pluggy-sdk": "^0.72.1",
+    "sequelize": "^6.37.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.8.7",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.3.3",
+    "sqlite3": "^5.1.6",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.4"
   }
 }

--- a/apps/backend/src/__tests__/auth.test.ts
+++ b/apps/backend/src/__tests__/auth.test.ts
@@ -1,0 +1,69 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import app from '../app';
+import sequelize from '../models';
+import User from '../models/User';
+
+beforeEach(async () => {
+  await sequelize.sync({ force: true });
+});
+
+describe('auth flow', () => {
+  it('registers a user', async () => {
+    const res = await request(app).post('/auth/register').send({
+      email: 'test@example.com',
+      password: 'password',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.email).toBe('test@example.com');
+  });
+
+  it('logs in successfully', async () => {
+    await User.create({
+      email: 'test@example.com',
+      passwordHash: 'hashed',
+    });
+    const bcrypt = await import('bcryptjs');
+    const user = await User.findOne({ where: { email: 'test@example.com' } });
+    if (user) {
+      user.passwordHash = await bcrypt.default.hash('password', 10);
+      await user.save();
+    }
+    const res = await request(app).post('/auth/login').send({
+      email: 'test@example.com',
+      password: 'password',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeTruthy();
+  });
+
+  it('fails login with wrong password', async () => {
+    const bcrypt = await import('bcryptjs');
+    await User.create({
+      email: 'test@example.com',
+      passwordHash: await bcrypt.default.hash('password', 10),
+    });
+    const res = await request(app).post('/auth/login').send({
+      email: 'test@example.com',
+      password: 'wrong',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('accesses protected route', async () => {
+    const bcrypt = await import('bcryptjs');
+    await User.create({
+      email: 'test@example.com',
+      passwordHash: await bcrypt.default.hash('password', 10),
+    });
+    const login = await request(app).post('/auth/login').send({
+      email: 'test@example.com',
+      password: 'password',
+    });
+    const res = await request(app)
+      .get('/auth/me')
+      .set('Authorization', `Bearer ${login.body.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('test@example.com');
+  });
+});

--- a/apps/backend/src/__tests__/setup.ts
+++ b/apps/backend/src/__tests__/setup.ts
@@ -1,0 +1,2 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.NODE_ENV = 'test';

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import authRoutes from './routes/auth';
+
+const app = express();
+
+app.use(express.json());
+app.use('/auth', authRoutes);
+
+export default app;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,1 +1,18 @@
-console.log('backend placeholder');
+import dotenv from 'dotenv';
+dotenv.config();
+
+import app from './app';
+import sequelize from './models';
+
+const port = process.env.PORT || 3000;
+
+(async () => {
+  try {
+    await sequelize.sync();
+    app.listen(port, () => {
+      console.log(`Server running on port ${port}`);
+    });
+  } catch (err) {
+    console.error('Failed to start server', err);
+  }
+})();

--- a/apps/backend/src/middlewares/authenticateToken.ts
+++ b/apps/backend/src/middlewares/authenticateToken.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthenticatedRequest extends Request {
+  userId?: string;
+}
+
+export default function authenticateToken(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.sendStatus(401);
+  }
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET as string) as {
+      userId: string;
+    };
+    req.userId = payload.userId;
+    next();
+  } catch {
+    return res.sendStatus(401);
+  }
+}

--- a/apps/backend/src/models/User.ts
+++ b/apps/backend/src/models/User.ts
@@ -1,0 +1,62 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from './index';
+
+export interface UserAttributes {
+  id: string;
+  name?: string | null;
+  email: string;
+  passwordHash: string;
+  plan: 'free' | 'pro';
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export type UserCreationAttributes = Optional<UserAttributes, 'id' | 'plan'>;
+
+class User
+  extends Model<UserAttributes, UserCreationAttributes>
+  implements UserAttributes
+{
+  public id!: string;
+  public name!: string | null;
+  public email!: string;
+  public passwordHash!: string;
+  public plan!: 'free' | 'pro';
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+User.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    passwordHash: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    plan: {
+      type: DataTypes.ENUM('free', 'pro'),
+      allowNull: false,
+      defaultValue: 'free',
+    },
+  },
+  {
+    sequelize,
+    modelName: 'User',
+    tableName: 'users',
+  },
+);
+
+export default User;

--- a/apps/backend/src/models/index.ts
+++ b/apps/backend/src/models/index.ts
@@ -1,0 +1,13 @@
+import { Sequelize } from 'sequelize';
+
+const databaseUrl =
+  process.env.NODE_ENV === 'test'
+    ? 'sqlite::memory:'
+    : (process.env.DATABASE_URL as string);
+
+export const sequelize = new Sequelize(databaseUrl, {
+  dialect: process.env.NODE_ENV === 'test' ? 'sqlite' : 'postgres',
+  logging: false,
+});
+
+export default sequelize;

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+import { body, validationResult } from 'express-validator';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User';
+import authenticateToken, { AuthenticatedRequest } from '../middlewares/authenticateToken';
+
+const router = Router();
+
+router.post(
+  '/register',
+  [
+    body('email').isEmail(),
+    body('password').isLength({ min: 6 }),
+    body('name').optional().isString(),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password, name } = req.body;
+    const existing = await User.findOne({ where: { email } });
+    if (existing) {
+      return res.status(400).json({ message: 'Email already in use' });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, name, passwordHash });
+    return res.status(201).json({ id: user.id, email: user.email, name: user.name, plan: user.plan });
+  },
+);
+
+router.post(
+  '/login',
+  [body('email').isEmail(), body('password').exists()],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    const user = await User.findOne({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const isValid = await bcrypt.compare(password, user.passwordHash);
+    if (!isValid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET as string, {
+      expiresIn: '1h',
+    });
+    return res.json({ token });
+  },
+);
+
+router.get('/me', authenticateToken, async (req: AuthenticatedRequest, res) => {
+  const user = await User.findByPk(req.userId);
+  if (!user) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  return res.json({ id: user.id, email: user.email, name: user.name, plan: user.plan });
+});
+
+export default router;

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,5 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["dist"],
+  "ts-node": { "files": true }
 }

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    setupFiles: ['src/__tests__/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add backend user model with plan support
- implement auth routes (register, login, me)
- add JWT middleware
- expose Express app and server bootstrap
- add Vitest-based tests for auth flow

## Testing
- `pnpm lint`
- `pnpm --filter @c2finance/backend test` *(fails: Could not locate the bindings file for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684e0ac101dc832a8e6cd2b8e527e9e0