### PR TITLE
Add sequelize models for user and session

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,0 +1,22 @@
+import { Sequelize } from 'sequelize';
+import { config } from 'dotenv';
+import { initUserModel, User } from './models/user';
+import { initSessionModel, Session } from './models/session';
+
+config();
+
+export const sequelize = new Sequelize(process.env.DATABASE_URL as string, {
+  logging: false,
+});
+
+initUserModel(sequelize);
+initSessionModel(sequelize);
+
+User.hasMany(Session, { foreignKey: 'user_id' });
+Session.belongsTo(User, { foreignKey: 'user_id' });
+
+if (['development', 'test'].includes(process.env.NODE_ENV || '')) {
+  sequelize.sync();
+}
+
+export { User, Session };

--- a/apps/backend/src/db/models/session.ts
+++ b/apps/backend/src/db/models/session.ts
@@ -1,0 +1,62 @@
+import {
+  DataTypes,
+  Model,
+  Sequelize,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from 'sequelize';
+import { User } from './user';
+
+export class Session extends Model<
+  InferAttributes<Session>,
+  InferCreationAttributes<Session>
+> {
+  declare id: CreationOptional<string>;
+  declare user_id: string;
+  declare token: string;
+  declare created_at: CreationOptional<Date>;
+  declare expires_at: Date;
+}
+
+export function initSessionModel(sequelize: Sequelize) {
+  Session.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      token: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      expires_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'sessions',
+      timestamps: true,
+      createdAt: 'created_at',
+      updatedAt: false,
+      underscored: true,
+    },
+  );
+
+  Session.belongsTo(User, { foreignKey: 'user_id' });
+
+  return Session;
+}

--- a/apps/backend/src/db/models/user.ts
+++ b/apps/backend/src/db/models/user.ts
@@ -1,0 +1,74 @@
+import bcrypt from 'bcryptjs';
+import {
+  DataTypes,
+  Model,
+  Sequelize,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from 'sequelize';
+
+export class User extends Model<
+  InferAttributes<User>,
+  InferCreationAttributes<User>
+> {
+  declare id: CreationOptional<string>;
+  declare name: string;
+  declare email: string;
+  declare password_hash: string;
+  declare password?: string;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initUserModel(sequelize: Sequelize) {
+  User.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password_hash: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      password: {
+        type: DataTypes.VIRTUAL,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'users',
+      timestamps: true,
+      underscored: true,
+    },
+  );
+
+  User.beforeCreate(async (user) => {
+    if (user.password) {
+      user.password_hash = await bcrypt.hash(user.password, 10);
+    }
+  });
+
+  return User;
+}


### PR DESCRIPTION
## Summary
- define Sequelize models for `User` and `Session`
- register the models in the database entrypoint
- sync the database automatically in dev and test envs

## Testing
- `npx vitest run`
- `npx tsc -p apps/backend/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684e1d85397c832a8f3cabd93a7a02db