### PR TITLE
Update env setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Este repositório contém apenas a configuração inicial e as dependências bá
 
 1. Clone o repositório
 2. Rode `pnpm install` na raiz do projeto.
+3. Execute `./setup-env.sh` para criar os arquivos `.env` e `.env.test` caso
+   ainda não existam.
 
 Scripts auxiliares:
 

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
+
 if [ ! -f .env ]; then
   cp .env.example .env
   echo "Created default .env file"
 else
   echo ".env already exists"
+fi
+
+if [ ! -f .env.test ]; then
+  cp .env.example .env.test
+  echo "Created default .env.test file"
+else
+  echo ".env.test already exists"
 fi


### PR DESCRIPTION
## Summary
- create `.env.test` from example if missing
- mention `setup-env.sh` in the usage instructions

## Testing
- `pnpm --filter './apps/*' run lint` *(fails: cannot find package 'typescript-eslint')*
- `pnpm -r test` *(fails: Database URL not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684f5231d46c832a88c6ac0b3203abda