### PR TITLE
Add goals and dashboard routes

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,12 +1,18 @@
 import express from 'express';
 import authRoutes from './routes/auth';
 import pluggyRoutes from './routes/pluggy';
+import goalRoutes from './routes/goals';
+import dashboardRoutes from './routes/dashboard';
+import advisorRoutes from './routes/advisor';
 
 export function createApp() {
   const app = express();
   app.use(express.json());
   app.use(authRoutes);
   app.use(pluggyRoutes);
+  app.use(goalRoutes);
+  app.use(dashboardRoutes);
+  app.use(advisorRoutes);
   return { app };
 }
 

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -4,6 +4,8 @@ import { Sequelize } from 'sequelize';
 import { initUserModel, User } from './models/user';
 import { initSessionModel, Session } from './models/session';
 import { initPluggyItemModel, PluggyItem } from './models/pluggyItem';
+import { initGoalModel, Goal } from './models/goal';
+import { initTransactionModel, Transaction } from './models/transaction';
 
 const envFile =
   process.env.NODE_ENV === 'test'
@@ -29,6 +31,8 @@ export const sequelize = new Sequelize(databaseUrl, {
 initUserModel(sequelize);
 initSessionModel(sequelize);
 initPluggyItemModel(sequelize);
+initGoalModel(sequelize);
+initTransactionModel(sequelize);
 
 User.hasMany(Session, { foreignKey: 'user_id' });
 Session.belongsTo(User, { foreignKey: 'user_id' });
@@ -36,9 +40,15 @@ Session.belongsTo(User, { foreignKey: 'user_id' });
 User.hasMany(PluggyItem, { foreignKey: 'user_id', as: 'pluggyItems' });
 PluggyItem.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
 
+User.hasMany(Goal, { foreignKey: 'user_id', as: 'goals' });
+Goal.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+
+User.hasMany(Transaction, { foreignKey: 'user_id', as: 'transactions' });
+Transaction.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+
 if (['development', 'test'].includes(process.env.NODE_ENV || '')) {
   sequelize.sync();
 }
 
-export { User, Session, PluggyItem };
+export { User, Session, PluggyItem, Goal, Transaction };
 export default sequelize;

--- a/apps/backend/src/db/models/goal.ts
+++ b/apps/backend/src/db/models/goal.ts
@@ -1,0 +1,59 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Goal extends Model<InferAttributes<Goal>, InferCreationAttributes<Goal>> {
+  declare id: CreationOptional<string>;
+  declare user_id: string;
+  declare month: string;
+  declare amount: number;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initGoalModel(sequelize: Sequelize) {
+  Goal.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      month: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      amount: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'goals',
+      timestamps: true,
+      underscored: true,
+    },
+  );
+
+  return Goal;
+}

--- a/apps/backend/src/db/models/transaction.ts
+++ b/apps/backend/src/db/models/transaction.ts
@@ -1,0 +1,59 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Transaction extends Model<InferAttributes<Transaction>, InferCreationAttributes<Transaction>> {
+  declare id: CreationOptional<string>;
+  declare user_id: string;
+  declare amount: number;
+  declare date: Date;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initTransactionModel(sequelize: Sequelize) {
+  Transaction.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      amount: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+      date: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'transactions',
+      timestamps: true,
+      underscored: true,
+    },
+  );
+
+  return Transaction;
+}

--- a/apps/backend/src/routes/advisor.ts
+++ b/apps/backend/src/routes/advisor.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/advisor/suggestion', (_req, res) => {
+  res.json({ suggestion: 'Consider saving 10% of your income this month' });
+});
+
+export default router;

--- a/apps/backend/src/routes/dashboard.ts
+++ b/apps/backend/src/routes/dashboard.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { authMiddleware } from '../middleware/auth';
+import { Goal } from '../db/models/goal';
+import { Transaction } from '../db/models/transaction';
+
+const router = Router();
+
+router.get('/dashboard/monthly', authMiddleware, async (req, res) => {
+  const user = req.user!;
+  const goals = await Goal.findAll({ where: { user_id: user.id } });
+  const transactions = await Transaction.findAll({ where: { user_id: user.id } });
+
+  const sums: Record<string, number> = {};
+  for (const tx of transactions) {
+    const month = tx.date.toISOString().slice(0, 7);
+    sums[month] = (sums[month] || 0) + tx.amount;
+  }
+
+  const result = goals.map((goal) => ({
+    month: goal.month,
+    goal: goal.amount,
+    spent: sums[goal.month] || 0,
+  }));
+
+  res.json(result);
+});
+
+export default router;

--- a/apps/backend/src/routes/goals.ts
+++ b/apps/backend/src/routes/goals.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { Goal } from '../db/models/goal';
+import { authMiddleware } from '../middleware/auth';
+
+const router = Router();
+
+router.post('/goals', authMiddleware, async (req, res) => {
+  const user = req.user!;
+  const { month, amount } = req.body || {};
+  if (!month || typeof amount !== 'number') {
+    res.status(400).json({ message: 'month and amount are required' });
+    return;
+  }
+  const goal = await Goal.create({ user_id: user.id, month, amount });
+  res.status(201).json(goal);
+});
+
+router.get('/goals', authMiddleware, async (req, res) => {
+  const user = req.user!;
+  const goals = await Goal.findAll({ where: { user_id: user.id } });
+  res.json(goals);
+});
+
+router.put('/goals/:id', authMiddleware, async (req, res) => {
+  const user = req.user!;
+  const { id } = req.params;
+  const { month, amount } = req.body || {};
+  const goal = await Goal.findOne({ where: { id, user_id: user.id } });
+  if (!goal) {
+    res.status(404).json({ message: 'Goal not found' });
+    return;
+  }
+  await goal.update({ month: month ?? goal.month, amount: amount ?? goal.amount });
+  res.json(goal);
+});
+
+router.delete('/goals/:id', authMiddleware, async (req, res) => {
+  const user = req.user!;
+  const { id } = req.params;
+  const goal = await Goal.findOne({ where: { id, user_id: user.id } });
+  if (!goal) {
+    res.status(404).json({ message: 'Goal not found' });
+    return;
+  }
+  await goal.destroy();
+  res.status(204).send();
+});
+
+export default router;

--- a/apps/backend/test/advisor.test.ts
+++ b/apps/backend/test/advisor.test.ts
@@ -1,0 +1,12 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import { createApp } from '../src/app';
+
+describe('advisor suggestion', () => {
+  it('returns a mocked recommendation', async () => {
+    const { app } = createApp();
+    const res = await request(app).get('/advisor/suggestion');
+    expect(res.status).toBe(200);
+    expect(res.body.suggestion).toBeTruthy();
+  });
+});

--- a/apps/backend/test/dashboard.test.ts
+++ b/apps/backend/test/dashboard.test.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createApp } from '../src/app';
+import { sequelize, Goal, Transaction } from '../src/db';
+
+describe('dashboard monthly', () => {
+  let app: ReturnType<typeof createApp>['app'];
+  let token: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ app } = createApp());
+    await sequelize.sync({ force: true });
+    const reg = await request(app)
+      .post('/register')
+      .send({ email: 'dash@test.com', password: 'pass' });
+    userId = reg.body.id;
+    const login = await request(app)
+      .post('/login')
+      .send({ email: 'dash@test.com', password: 'pass' });
+    token = login.body.token;
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  it('aggregates transactions per month', async () => {
+    await Goal.bulkCreate([
+      { user_id: userId, month: '2024-01', amount: 200 },
+      { user_id: userId, month: '2024-02', amount: 100 },
+    ]);
+    await Transaction.bulkCreate([
+      { user_id: userId, amount: 50, date: new Date('2024-01-05') },
+      { user_id: userId, amount: 30, date: new Date('2024-02-10') },
+      { user_id: userId, amount: 20, date: new Date('2024-02-15') },
+    ]);
+
+    const res = await request(app)
+      .get('/dashboard/monthly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { month: '2024-01', goal: 200, spent: 50 },
+      { month: '2024-02', goal: 100, spent: 50 },
+    ]);
+  });
+});

--- a/apps/backend/test/goals.test.ts
+++ b/apps/backend/test/goals.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createApp } from '../src/app';
+import { sequelize } from '../src/db';
+
+describe('goal routes', () => {
+  let app: ReturnType<typeof createApp>['app'];
+  let token: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ app } = createApp());
+    await sequelize.sync({ force: true });
+    const reg = await request(app)
+      .post('/register')
+      .send({ email: 'goal@test.com', password: 'pass' });
+    userId = reg.body.id;
+    const login = await request(app)
+      .post('/login')
+      .send({ email: 'goal@test.com', password: 'pass' });
+    token = login.body.token;
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  it('creates, updates and deletes a goal', async () => {
+    const create = await request(app)
+      .post('/goals')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ month: '2024-01', amount: 100 });
+    expect(create.status).toBe(201);
+    const id = create.body.id;
+
+    const list = await request(app)
+      .get('/goals')
+      .set('Authorization', `Bearer ${token}`);
+    expect(list.body.length).toBe(1);
+
+    const update = await request(app)
+      .put(`/goals/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 150 });
+    expect(update.body.amount).toBe(150);
+
+    const del = await request(app)
+      .delete(`/goals/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(del.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- goal routes for CRUD operations
- dashboard route to aggregate transactions by month
- advisor suggestion route
- wire new routes in express app
- tests for new endpoints

## Testing
- `NODE_ENV=test pnpm --filter "./apps/backend" test` *(fails: Database URL not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684f52370870832abd159b1ea1521ce1