### PR TITLE
Update backend vitest config

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,2 +1,12 @@
 import { defineConfig } from 'vitest/config';
-export default defineConfig({ test: { include: ['test/**/*.ts'] } });
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- load test env variables in backend vitest config
- ensure NODE_ENV is set to `test`

## Testing
- `pnpm --filter @c2finance/backend test` *(fails: password authentication failed for user "user")*

------
https://chatgpt.com/codex/tasks/task_e_684f523d8e04832a8a7ea8a6cbe0b27b