### PR TITLE
Add basic finance models

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -4,11 +4,15 @@ import { Sequelize } from 'sequelize';
 import { initUserModel, User } from './models/user';
 import { initSessionModel, Session } from './models/session';
 import { initPluggyItemModel, PluggyItem } from './models/pluggyItem';
+import { initAccountModel, Account } from './models/account';
+import { initTransactionModel, Transaction } from './models/transaction';
+import { initCategoryModel, Category } from './models/category';
+import { initGoalModel, Goal } from './models/goal';
 
 const envFile =
   process.env.NODE_ENV === 'test'
-    ? path.resolve(__dirname, '../../../.env.test')
-    : path.resolve(__dirname, '../../../.env');
+    ? path.resolve(__dirname, '../../../../.env.test')
+    : path.resolve(__dirname, '../../../../.env');
 
 dotenv.config({ path: envFile });
 
@@ -29,6 +33,10 @@ export const sequelize = new Sequelize(databaseUrl, {
 initUserModel(sequelize);
 initSessionModel(sequelize);
 initPluggyItemModel(sequelize);
+initAccountModel(sequelize);
+initTransactionModel(sequelize);
+initCategoryModel(sequelize);
+initGoalModel(sequelize);
 
 User.hasMany(Session, { foreignKey: 'user_id' });
 Session.belongsTo(User, { foreignKey: 'user_id' });
@@ -36,9 +44,33 @@ Session.belongsTo(User, { foreignKey: 'user_id' });
 User.hasMany(PluggyItem, { foreignKey: 'user_id', as: 'pluggyItems' });
 PluggyItem.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
 
+User.hasMany(Account, { foreignKey: 'user_id', as: 'accounts' });
+Account.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+
+User.hasMany(Transaction, { foreignKey: 'user_id', as: 'transactions' });
+Account.hasMany(Transaction, { foreignKey: 'account_id', as: 'transactions' });
+Transaction.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+Transaction.belongsTo(Account, { foreignKey: 'account_id', as: 'account' });
+
+Category.hasMany(Transaction, { foreignKey: 'category_id', as: 'transactions' });
+Category.hasMany(Goal, { foreignKey: 'category_id', as: 'goals' });
+Transaction.belongsTo(Category, { foreignKey: 'category_id', as: 'category' });
+Goal.belongsTo(Category, { foreignKey: 'category_id', as: 'category' });
+
+User.hasMany(Goal, { foreignKey: 'user_id', as: 'goals' });
+Goal.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+
 if (['development', 'test'].includes(process.env.NODE_ENV || '')) {
   sequelize.sync();
 }
 
-export { User, Session, PluggyItem };
+export {
+  User,
+  Session,
+  PluggyItem,
+  Account,
+  Transaction,
+  Category,
+  Goal,
+};
 export default sequelize;

--- a/apps/backend/src/db/models/account.ts
+++ b/apps/backend/src/db/models/account.ts
@@ -1,0 +1,63 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Account extends Model<
+  InferAttributes<Account>,
+  InferCreationAttributes<Account>
+> {
+  declare id: CreationOptional<string>;
+  declare user_id: string;
+  declare name: string;
+  declare balance: CreationOptional<number>;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initAccountModel(sequelize: Sequelize) {
+  Account.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      balance: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false,
+        defaultValue: 0,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'accounts',
+      underscored: true,
+      timestamps: true,
+    },
+  );
+
+  return Account;
+}

--- a/apps/backend/src/db/models/category.ts
+++ b/apps/backend/src/db/models/category.ts
@@ -1,0 +1,53 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Category extends Model<
+  InferAttributes<Category>,
+  InferCreationAttributes<Category>
+> {
+  declare id: CreationOptional<string>;
+  declare name: string;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initCategoryModel(sequelize: Sequelize) {
+  Category.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'categories',
+      underscored: true,
+      timestamps: true,
+    },
+  );
+
+  return Category;
+}

--- a/apps/backend/src/db/models/goal.ts
+++ b/apps/backend/src/db/models/goal.ts
@@ -1,0 +1,62 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Goal extends Model<
+  InferAttributes<Goal>,
+  InferCreationAttributes<Goal>
+> {
+  declare id: CreationOptional<string>;
+  declare user_id: string;
+  declare category_id: string;
+  declare amount: number;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initGoalModel(sequelize: Sequelize) {
+  Goal.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      category_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      amount: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'goals',
+      underscored: true,
+      timestamps: true,
+    },
+  );
+
+  return Goal;
+}

--- a/apps/backend/src/db/models/transaction.ts
+++ b/apps/backend/src/db/models/transaction.ts
@@ -1,0 +1,77 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export class Transaction extends Model<
+  InferAttributes<Transaction>,
+  InferCreationAttributes<Transaction>
+> {
+  declare id: CreationOptional<string>;
+  declare account_id: string;
+  declare user_id: string;
+  declare category_id: string | null;
+  declare amount: number;
+  declare description: CreationOptional<string>;
+  declare date: CreationOptional<Date>;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+export function initTransactionModel(sequelize: Sequelize) {
+  Transaction.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      account_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      category_id: {
+        type: DataTypes.UUID,
+        allowNull: true,
+      },
+      amount: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      description: {
+        type: DataTypes.STRING,
+      },
+      date: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'transactions',
+      underscored: true,
+      timestamps: true,
+    },
+  );
+
+  return Transaction;
+}


### PR DESCRIPTION
## Summary
- add Account, Transaction, Category and Goal Sequelize models
- wire up new models and associations in db/index

## Testing
- `pnpm --filter ./apps/backend lint` *(fails: Cannot find package 'typescript-eslint')*
- `NODE_ENV=test pnpm --filter ./apps/backend test` *(fails: SASL authentication error)*

------
https://chatgpt.com/codex/tasks/task_e_684f523e9f34832ab11a9475edc71fc7