### PR TITLE
Update README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este repositório contém apenas a configuração inicial e as dependências bá
 
 ## Estrutura
 
-- **apps/backend**: API em Node.js/Express (sem código funcional ainda).
+- **apps/backend**: API em Node.js/Express com rotas de autenticação (`/register`, `/login`, `/me`) e endpoint `/pluggy/item` para salvar o id do item.
 - **apps/frontend**: Frontend em React + Tailwind via Vite.
 - **packages/shared**: Código compartilhado entre os apps.
 
@@ -14,6 +14,8 @@ Este repositório contém apenas a configuração inicial e as dependências bá
 
 1. Clone o repositório
 2. Rode `pnpm install` na raiz do projeto.
+3. Execute `./setup-env.sh` para criar o arquivo `.env`.
+4. Inicie o backend com `pnpm --filter @c2finance/backend dev` e o frontend com `pnpm --filter @c2finance/frontend dev`.
 
 Scripts auxiliares:
 


### PR DESCRIPTION
## Summary
- document auth and pluggy routes in Estrutura section
- add setup-env and dev server commands in Uso section

## Testing
- `pnpm lint` *(fails: cannot find typescript-eslint)*
- `pnpm test` *(fails: Database URL not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684f5242c138832a9a6ba7e6222bbf65