### PR TITLE
Ensure req.user typing after authMiddleware

### DIFF
--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -1,9 +1,10 @@
-import { Request, Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { Session } from '../db/models/session';
 import { User } from '../db/models/user';
+import { AuthRequest } from '../types/authRequest';
 
-export async function authMiddleware(req: Request, res: Response, next: NextFunction) {
+export async function authMiddleware(req: AuthRequest, res: Response, next: NextFunction) {
   const auth = req.header('Authorization');
   if (!auth || !auth.startsWith('Bearer ')) {
     res.status(401).json({ message: 'Unauthorized' });

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { User } from '../db/models/user';
+import { AuthRequest } from '../types/authRequest';
 import { Session } from '../db/models/session';
 import { authMiddleware } from '../middleware/auth';
 
@@ -45,8 +46,8 @@ router.post('/login', async (req, res) => {
 });
 
 
-router.get('/me', authMiddleware, (req, res) => {
-  const user = req.user as User;
+router.get('/me', authMiddleware, (req: AuthRequest, res) => {
+  const user = req.user;
   res.json({ id: user.id, email: user.email });
 });
 

--- a/apps/backend/src/routes/pluggy.ts
+++ b/apps/backend/src/routes/pluggy.ts
@@ -1,16 +1,17 @@
 import { Router } from 'express';
 import { PluggyItem } from '../db/models/pluggyItem';
 import { authMiddleware } from '../middleware/auth';
+import { AuthRequest } from '../types/authRequest';
 
 const router = Router();
 
-router.post('/pluggy/item', authMiddleware, async (req, res) => {
+router.post('/pluggy/item', authMiddleware, async (req: AuthRequest, res) => {
   const { pluggyItemId } = req.body || {};
   if (!pluggyItemId) {
     res.status(400).json({ message: 'pluggyItemId is required' });
     return;
   }
-  const user = req.user!;
+  const user = req.user;
   const item = await PluggyItem.create({
     user_id: user.id,
     pluggy_item_id: pluggyItemId,

--- a/apps/backend/src/types/authRequest.ts
+++ b/apps/backend/src/types/authRequest.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express';
+import { User } from '../db/models/user';
+
+export interface AuthRequest extends Request {
+  user: User;
+}


### PR DESCRIPTION
## Summary
- add `AuthRequest` interface
- update `authMiddleware` and routes to use `AuthRequest`

## Testing
- `pnpm test` *(fails: Database URL not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684f55df3334832a9df9724f99f6bcdc