### PR TITLE
Fix Goal model duplication

### DIFF
--- a/apps/backend/src/db/models/goal.ts
+++ b/apps/backend/src/db/models/goal.ts
@@ -7,10 +7,6 @@ import {
   Sequelize,
 } from 'sequelize';
 
-export class Goal extends Model<InferAttributes<Goal>, InferCreationAttributes<Goal>> {
-  declare id: CreationOptional<string>;
-  declare user_id: string;
-  declare month: string;
 export class Goal extends Model<
   InferAttributes<Goal>,
   InferCreationAttributes<Goal>
@@ -18,6 +14,7 @@ export class Goal extends Model<
   declare id: CreationOptional<string>;
   declare user_id: string;
   declare category_id: string;
+  declare month: string;
   declare amount: number;
   declare created_at: CreationOptional<Date>;
   declare updated_at: CreationOptional<Date>;
@@ -35,14 +32,12 @@ export function initGoalModel(sequelize: Sequelize) {
         type: DataTypes.UUID,
         allowNull: false,
       },
-      month: {
-        type: DataTypes.STRING,
-        allowNull: false,
-      },
-      amount: {
-        type: DataTypes.FLOAT,
       category_id: {
         type: DataTypes.UUID,
+        allowNull: false,
+      },
+      month: {
+        type: DataTypes.STRING,
         allowNull: false,
       },
       amount: {
@@ -63,8 +58,6 @@ export function initGoalModel(sequelize: Sequelize) {
     {
       sequelize,
       tableName: 'goals',
-      timestamps: true,
-      underscored: true,
       underscored: true,
       timestamps: true,
     },


### PR DESCRIPTION
## Summary
- fix duplicate Goal model
- correct Goal.init fields

## Testing
- `pnpm --filter "./apps/*" lint` *(fails: Cannot find package 'typescript-eslint')*
- `pnpm --filter "./apps/*" test` *(fails: failed to load vitest config)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a3000d0832aabf0041fa39362ac