### PR TITLE
Fix backend vitest config

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -2,15 +2,8 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
-
-export default defineConfig({
-
-import dotenv from 'dotenv';
-import path from 'path';
-
-dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
 process.env.NODE_ENV = 'test';
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- dedupe imports in backend vitest config
- ensure NODE_ENV is `test`
- load `.env.test`

## Testing
- `pnpm -r test` *(fails: Multiple exports with the same name)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a24cadc832a848427e9fcc8dfef