### PR TITLE
Fix advisor router export

### DIFF
--- a/apps/backend/src/routes/advisor.ts
+++ b/apps/backend/src/routes/advisor.ts
@@ -8,8 +8,7 @@ router.get('/advisor/messages', authMiddleware, (_req, res) => {
     { id: 1, text: 'Keep saving 10% of your income.' },
     { id: 2, text: 'Consider reducing discretionary spending.' },
   ]);
-
-const router = Router();
+});
 
 router.get('/advisor/suggestion', (_req, res) => {
   res.json({ suggestion: 'Consider saving 10% of your income this month' });


### PR DESCRIPTION
## Summary
- close `/advisor/messages` route handler properly
- remove duplicate router and export the same router instance

## Testing
- `pnpm test` *(fails: vitest config issue)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a293300832aa1d1ea4d98522230