### PR TITLE
docs: update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Este repositório contém apenas a configuração inicial e as dependências bá
 2. Rode `pnpm install` na raiz do projeto.
 3. Execute `./setup-env.sh` para criar os arquivos `.env` e `.env.test` caso
    ainda não existam.
-3. Execute `./setup-env.sh` para criar o arquivo `.env`.
 4. Inicie o backend com `pnpm --filter @c2finance/backend dev` e o frontend com `pnpm --filter @c2finance/frontend dev`.
 
 Scripts auxiliares:
 
 - `pnpm lint` — verifica o código com ESLint.
 - `pnpm format` — formata com Prettier.
+- `pnpm --filter @c2finance/backend test` — executa os testes do backend.
+- `pnpm --filter @c2finance/frontend test` — executa os testes do frontend.
 
 ## Licença
 


### PR DESCRIPTION
## Summary
- remove duplicate setup step
- fix numbered list
- document backend and frontend test commands

## Testing
- `pnpm --filter @c2finance/backend test` *(fails: Expected ":" but found "dotenv")*
- `pnpm --filter @c2finance/frontend test` *(fails: Failed to resolve import "@testing-library/react")*

------
https://chatgpt.com/codex/tasks/task_e_684f5a21a28c832a90ac5c6d000b9a16